### PR TITLE
In close(), wait for all handlers to settle.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,16 +36,11 @@ export function onInterrupt(handler: Handler): void {
  */
 export async function promiseAllStrict(
       promises: Promise<any>[]): Promise<void> {
-  let error: any = null;
-  for (const promise of promises) {
-    try {
-      await promise;
-    } catch (e) {
-      error = error || e;
-    }
-  }
-  if (error) {
-    throw error;
+  let errors = await Promise.all(
+      promises.map((p) => p.then(() => null, (e) => e)));
+  let firstError = errors.find((e) => e != null);
+  if (firstError) {
+    throw firstError;
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,24 @@ export function onInterrupt(handler: Handler): void {
 }
 
 /**
+ * Waits for all promises to settle, then rejects with the first error, if any.
+ */
+export async function promiseAllStrict(
+      promises: Promise<any>[]): Promise<void> {
+  let error: any = null;
+  for (const promise of promises) {
+    try {
+      await promise;
+    } catch (e) {
+      error = error || e;
+    }
+  }
+  if (error) {
+    throw error;
+  }
+}
+
+/**
  * Call all interrupt handlers, and call the callback when they all complete.
  *
  * Clears the list of interrupt handlers.
@@ -40,7 +58,8 @@ export async function close(): Promise<void> {
   const promises = interruptHandlers.map((handler) => handler());
   // Empty the array in place. Looks weird, totally works.
   interruptHandlers.length = 0;
-  await Promise.all(promises);
+
+  await promiseAllStrict(promises);
 }
 
 let interrupted = false;


### PR DESCRIPTION
It occurred to me that we probably do want `close` to wait for all handlers to settle, even if one of them throws.
